### PR TITLE
Repair module name

### DIFF
--- a/lib/login_mention_account_type/hooks.rb
+++ b/lib/login_mention_account_type/hooks.rb
@@ -1,6 +1,6 @@
 # vim: set sw=2 sts=2 et tw=80 :
 
-module RedmineLoginMentionAccountType
+module LoginMentionAccountType
   class Hooks < Redmine::Hook::ViewListener
     render_on :view_account_login_top,
               :partial => 'view_account_login_top'


### PR DESCRIPTION
Resolve error on modern versions of Redmine/Ruby:

```
bundler: failed to load command: /usr/bin/unicorn_rails.ruby2.7
NameError: uninitialized constant LoginMentionAccountType::Hooks
```